### PR TITLE
Always call the Content Manager started callback even when already started. 

### DIFF
--- a/dtglib/src/main/java/com/kaltura/dtg/clear/ContentManagerImp.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/clear/ContentManagerImp.java
@@ -136,6 +136,10 @@ public class ContentManagerImp extends ContentManager {
     public void start(final OnStartedListener onStartedListener) {
 
         if (started) {
+            //Call the onstarted callback even if it has already been started
+            if(onStartedListener != null){
+                onStartedListener.onStarted();
+            }
             return;
         }
 

--- a/dtglib/src/main/java/com/kaltura/dtg/clear/ContentManagerImp.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/clear/ContentManagerImp.java
@@ -137,7 +137,7 @@ public class ContentManagerImp extends ContentManager {
 
         if (started) {
             // Call the onstarted callback even if it has already been started
-            if (onStartedListener != null){
+            if (onStartedListener != null) {
                 onStartedListener.onStarted();
             }
             return;

--- a/dtglib/src/main/java/com/kaltura/dtg/clear/ContentManagerImp.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/clear/ContentManagerImp.java
@@ -136,8 +136,8 @@ public class ContentManagerImp extends ContentManager {
     public void start(final OnStartedListener onStartedListener) {
 
         if (started) {
-            //Call the onstarted callback even if it has already been started
-            if(onStartedListener != null){
+            // Call the onstarted callback even if it has already been started
+            if (onStartedListener != null){
                 onStartedListener.onStarted();
             }
             return;


### PR DESCRIPTION
Currently when using the content manager there seems to be no way to check if the content manager is started nor know if the started callback will be called or noth. I have
 Modified ContentManagerImp.java to always call the onStartedListenter when start is called even if it has already been started.