### PR TITLE
Fix concurrent downloads 

### DIFF
--- a/dtglib/src/main/java/com/kaltura/dtg/clear/ContentManagerImp.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/clear/ContentManagerImp.java
@@ -121,7 +121,7 @@ public class ContentManagerImp extends ContentManager {
 
     @Override
     public void setMaxConcurrentDownloads(int maxConcurrentDownloads) {
-        if(started){
+        if (started){
             throw new IllegalStateException("Max concurrent downloads cannot be set after the Content manager has been started.");
         }
         this.maxConcurrentDownloads = maxConcurrentDownloads;

--- a/dtglib/src/main/java/com/kaltura/dtg/clear/ContentManagerImp.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/clear/ContentManagerImp.java
@@ -121,10 +121,12 @@ public class ContentManagerImp extends ContentManager {
 
     @Override
     public void setMaxConcurrentDownloads(int maxConcurrentDownloads) {
+        if(started){
+            throw new IllegalStateException("Max concurrent downloads cannot be set after the Content manager has been started.");
+        }
         this.maxConcurrentDownloads = maxConcurrentDownloads;
     }
-
-
+    
     @Override
     public void stop() {
         provider.stop();

--- a/dtglib/src/main/java/com/kaltura/dtg/clear/DefaultDownloadService.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/clear/DefaultDownloadService.java
@@ -29,7 +29,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
-import java.util.concurrent.TimeUnit;
 
 public class DefaultDownloadService extends Service {
 
@@ -165,16 +164,9 @@ public class DefaultDownloadService extends Service {
      * It does this by allocating a new fixed size thread pool.
      * The way this library is currently constructed there should
      * never be any ongoing downloads when setMaxConcurrentDownloads are called.
-     * However, we do wait for any existing threads to terminate just in case.
      */
     public void setMaxConcurrentDownloads(int maxConcurrentDownloads) {
         this.maxConcurrentDownloads = maxConcurrentDownloads;
-        try {
-            //Wait for any existing threads to complete.
-            mExecutor.awaitTermination(1, TimeUnit.MINUTES);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
         mExecutor = Executors.newFixedThreadPool(maxConcurrentDownloads);
     }
 


### PR DESCRIPTION
Fix the setting of max concurrent downloads for Content Manager. 
Library will now throw an IllegalStateException when setMaxConcurrentDownloads is called after content manger has been started. 