### PR TITLE
Fix concurrent downloads  (#8)

### DIFF
--- a/dtglib/src/main/java/com/kaltura/dtg/clear/ContentManagerImp.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/clear/ContentManagerImp.java
@@ -121,10 +121,12 @@ public class ContentManagerImp extends ContentManager {
 
     @Override
     public void setMaxConcurrentDownloads(int maxConcurrentDownloads) {
+        if (started){
+            throw new IllegalStateException("Max concurrent downloads cannot be set after the Content manager has been started.");
+        }
         this.maxConcurrentDownloads = maxConcurrentDownloads;
     }
-
-
+    
     @Override
     public void stop() {
         provider.stop();

--- a/dtglib/src/main/java/com/kaltura/dtg/clear/DefaultDownloadService.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/clear/DefaultDownloadService.java
@@ -159,8 +159,15 @@ public class DefaultDownloadService extends Service {
         return super.onUnbind(intent);
     }
 
+    /**
+     * This method changes the number of threads that are used to download the chunks.
+     * It does this by allocating a new fixed size thread pool.
+     * The way this library is currently constructed there should
+     * never be any ongoing downloads when setMaxConcurrentDownloads are called.
+     */
     public void setMaxConcurrentDownloads(int maxConcurrentDownloads) {
         this.maxConcurrentDownloads = maxConcurrentDownloads;
+        mExecutor = Executors.newFixedThreadPool(maxConcurrentDownloads);
     }
 
     public void startListenerThread(){


### PR DESCRIPTION
* Fix issue where setting max concurrent downloads was not setting the max concurrent downloads.
Add exception to be thrown when you try to set the max concurrent downloads after the Content manager has started already.