### PR TITLE
Support offline playback for downloaded HLS encrypted streams

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ android:
   - platform-tools
   - tools
   - extra-android-m2repository
+  - build-tools-25.0.2
+  - android-25
 cache:
   directories:
     - $HOME/.gradle/caches/

--- a/dtglib/src/main/java/com/kaltura/android/exoplayer/hls/HlsPlaylistParser.java
+++ b/dtglib/src/main/java/com/kaltura/android/exoplayer/hls/HlsPlaylistParser.java
@@ -312,6 +312,23 @@ public final class HlsPlaylistParser implements UriLoadable.Parser<HlsPlaylist> 
         Collections.unmodifiableList(segments));
   }
 
+  /**
+   * @param line
+   * @return URI attribute if it's detected
+   * @throws ParserException
+   */
+  public String extractUriAttribute(String line) throws ParserException {
+    return HlsParserUtil.parseStringAttr(line, URI_ATTR_REGEX, URI_ATTR);
+  }
+
+  /**
+   * @param line
+   * @return true if AES-128 method detected, false otherwise
+   */
+  public Boolean containsEncryptionKey(String line) {
+    return line.contains(METHOD_AES128);
+  }
+
   private static class LineIterator {
 
     private final BufferedReader reader;

--- a/dtglib/src/main/java/com/kaltura/dtg/clear/HLSParser.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/clear/HLSParser.java
@@ -2,15 +2,14 @@ package com.kaltura.dtg.clear;
 
 import android.text.TextUtils;
 import android.util.Log;
-
 import com.kaltura.android.exoplayer.hls.HlsMasterPlaylist;
 import com.kaltura.android.exoplayer.hls.HlsMediaPlaylist;
+import com.kaltura.android.exoplayer.hls.HlsMediaPlaylist.Segment;
 import com.kaltura.android.exoplayer.hls.HlsPlaylist;
 import com.kaltura.android.exoplayer.hls.HlsPlaylistParser;
 import com.kaltura.android.exoplayer.hls.Variant;
 import com.kaltura.dtg.DownloadItem;
 import com.kaltura.dtg.Utils;
-
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -212,6 +211,9 @@ class HLSParser {
             if (!line.isEmpty() && line.charAt(0) != '#') {
                 lines[i] = Utils.getHashedFileName(line);
             }
+            if(sPlaylistParser.containsEncryptionKey(line)) {
+                lines[i] = replaceRemoteEncryptionKeyWithLocal(line);
+            }
             Log.d(TAG, String.format("rename in playlist: '%s' ==> '%s'", line, lines[i]));
         }
         String modifiedData = TextUtils.join("\n", lines);
@@ -244,6 +246,10 @@ class HLSParser {
                     segmentURL, segmentFile, segment.url, Utils.getHashedFileName(segment.url)));
 
             downloadTasks.add(new DownloadTask(segmentURL, segmentFile));
+
+            if(segment.isEncrypted) {
+                downloadTasks.add(createEncryptionKeyDownloadTask(segment));
+            }
         }
 
         return new ArrayList<>(downloadTasks);
@@ -255,6 +261,42 @@ class HLSParser {
 
     public String getPlaybackPath() {
         return FILTERED_MASTER_M3U8;
+    }
+
+    /**
+     * Modifies encryption remote url to an local one that will be loaded in createDownloadTasks()
+     * @param encryptionKeyLine
+     * @return
+     */
+    private String replaceRemoteEncryptionKeyWithLocal(String encryptionKeyLine) {
+        try {
+            String encryptionUri = sPlaylistParser.extractUriAttribute(encryptionKeyLine);
+            String encryptionKeyFileName = createEncryptionKeyFileName(encryptionUri);
+            return encryptionKeyLine.replace(encryptionUri, encryptionKeyFileName);
+        } catch (Exception e) {
+            return encryptionKeyLine;
+        }
+    }
+
+    /**
+     * @param segment
+     * @return DownloadTask for the remote encryption file. File name matches with the one stored
+     * in replaceRemoteEncryptionKeyWithLocal() method and the variant.m3u8 file
+     * @throws MalformedURLException
+     */
+    private DownloadTask createEncryptionKeyDownloadTask(Segment segment) throws MalformedURLException  {
+        String encryptionKeyFileName = createEncryptionKeyFileName(segment.encryptionKeyUri);
+        File encryptionKeyFile = new File(targetDirectory, encryptionKeyFileName);
+        URL encryptionKeyURL = new URL(segment.encryptionKeyUri);
+        return new DownloadTask(encryptionKeyURL, encryptionKeyFile);
+    }
+
+    /**
+     * @param encryptionKeyUri
+     * @return Encrypted filename for AES-128 key file that should replace the remote key URI
+     */
+    private String createEncryptionKeyFileName(String encryptionKeyUri) {
+        return Utils.getHashedFileName(encryptionKeyUri);
     }
 
     static class DownloadedPlaylist {


### PR DESCRIPTION
With the current version of DTG lib [2.2.0](https://github.com/kaltura/playkit-dtg-android/releases/tag/v2.2.0) there is no way to play downloaded encrypted HLS streams because they contain the remote URI for the encryption key.  This URI is useless and inaccessible in offline mode.
It should be stored in the same folder along with the `.ts` and `.m3u8` files. The `variant.m3u8` file is updated accordingly using the local key path.

This PR introduces `AES-128` encryption key downloading for HLS streams so in offline playback the local key file path will be used.

The result of the key download shown in the console screenshots below

**Before**

<img width="1346" alt="screen shot 2017-08-07 at 4 50 34 pm" src="https://user-images.githubusercontent.com/1655758/29029965-2611bc06-7b92-11e7-8eb1-d31d8caa800f.png">

**After**

<img width="1341" alt="screen shot 2017-08-07 at 2 44 07 pm" src="https://user-images.githubusercontent.com/1655758/29025466-7f8c0fba-7b7f-11e7-9427-ec033e846504.png">