### PR TITLE
Performance improvements

### DIFF
--- a/dtglib/src/main/java/com/kaltura/dtg/Utils.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/Utils.java
@@ -194,7 +194,7 @@ public class Utils {
                 throw new IOException("Response code from HEAD request: " + responseCode);
             }
             String contentLength = connection.getHeaderField("Content-Length");
-            if (contentLength != null && !contentLength.equals("")) {
+            if (!TextUtils.isEmpty(contentLength)) {
                 return Long.parseLong(contentLength);
             } else {
                 return -1;

--- a/dtglib/src/main/java/com/kaltura/dtg/clear/Database.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/clear/Database.java
@@ -506,6 +506,10 @@ class Database {
         return items;
     }
 
+    synchronized int countPendingFiles(String itemId) {
+        return countPendingFiles(itemId, null);
+    }
+    
     synchronized int countPendingFiles(String itemId, @Nullable String trackId) {
 
         SQLiteDatabase db = database;
@@ -514,11 +518,14 @@ class Database {
 
         try {
             if (trackId != null) {
-                cursor = db.rawQuery("SELECT COUNT(*) FROM " + TBL_DOWNLOAD_FILES +
-                        " WHERE " + COL_ITEM_ID + "==? AND " + COL_FILE_COMPLETE + "==0 AND " + COL_TRACK_REL_ID + "=?", new String[]{itemId, trackId});
+                String sql = "SELECT COUNT(*) FROM " + TBL_DOWNLOAD_FILES +
+                        " WHERE " + COL_ITEM_ID + "==? AND " + COL_FILE_COMPLETE + "==0 AND " + COL_TRACK_REL_ID + "==?";
+                cursor = db.rawQuery(sql, new String[]{itemId, trackId});
+                
             } else {
-                cursor = db.rawQuery("SELECT COUNT(*) FROM " + TBL_DOWNLOAD_FILES +
-                        " WHERE " + COL_ITEM_ID + "==? AND " + COL_FILE_COMPLETE + "==0", new String[]{itemId});
+                String sql = "SELECT COUNT(*) FROM " + TBL_DOWNLOAD_FILES +
+                        " WHERE " + COL_ITEM_ID + "==? AND " + COL_FILE_COMPLETE + "==0";
+                cursor = db.rawQuery(sql, new String[]{itemId});
             }
 
             if (cursor.moveToFirst()) {

--- a/dtglib/src/main/java/com/kaltura/dtg/clear/DefaultDownloadService.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/clear/DefaultDownloadService.java
@@ -8,7 +8,6 @@ import android.os.Binder;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.IBinder;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
@@ -36,7 +35,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
-import java.util.concurrent.ThreadFactory;
 
 public class DefaultDownloadService extends Service {
 
@@ -54,15 +52,6 @@ public class DefaultDownloadService extends Service {
     private ContentManager.Settings settings;
     
     private Set<String> removedItems = new HashSet<>();
-    private ThreadFactory executorThreadFactory = new ThreadFactory() {
-        ThreadFactory inner = Executors.defaultThreadFactory();
-        @Override
-        public Thread newThread(@NonNull Runnable r) {
-            Thread thread = inner.newThread(r);
-            thread.setPriority(2);
-            return thread;
-        }
-    };
 
     private final DownloadTask.Listener mDownloadTaskListener = new DownloadTask.Listener() {
 
@@ -259,9 +248,8 @@ public class DefaultDownloadService extends Service {
         database = new Database(dbFile, this);
 
         startHandlerThreads();
-        mExecutor = Executors.newFixedThreadPool(settings.maxConcurrentDownloads, executorThreadFactory);
 
-
+        mExecutor = Executors.newFixedThreadPool(settings.maxConcurrentDownloads);
 
         started = true;
     }

--- a/dtglib/src/main/java/com/kaltura/dtg/clear/DefaultDownloadService.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/clear/DefaultDownloadService.java
@@ -447,9 +447,8 @@ public class DefaultDownloadService extends Service {
     public void pauseDownload(final DefaultDownloadItem item) {
         assertStarted();
 
-        ArrayList<DownloadTask> downloadTasks;
         if (item != null) {
-            int countPendingFiles = database.countPendingFiles(item.getItemId(), null);
+            int countPendingFiles = database.countPendingFiles(item.getItemId());
             if (countPendingFiles > 0) {
 
                 pauseItemDownload(item.getItemId());

--- a/dtglib/src/main/java/com/kaltura/dtg/clear/DefaultDownloadService.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/clear/DefaultDownloadService.java
@@ -449,8 +449,8 @@ public class DefaultDownloadService extends Service {
 
         ArrayList<DownloadTask> downloadTasks;
         if (item != null) {
-            downloadTasks = database.readPendingDownloadTasksFromDB(item.getItemId());
-            if (downloadTasks.size() > 0) {
+            int countPendingFiles = database.countPendingFiles(item.getItemId(), null);
+            if (countPendingFiles > 0) {
 
                 pauseItemDownload(item.getItemId());
 

--- a/dtglib/src/main/java/com/kaltura/dtg/clear/DefaultDownloadService.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/clear/DefaultDownloadService.java
@@ -8,6 +8,7 @@ import android.os.Binder;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.IBinder;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
@@ -35,6 +36,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
+import java.util.concurrent.ThreadFactory;
 
 public class DefaultDownloadService extends Service {
 
@@ -52,6 +54,15 @@ public class DefaultDownloadService extends Service {
     private ContentManager.Settings settings;
     
     private Set<String> removedItems = new HashSet<>();
+    private ThreadFactory executorThreadFactory = new ThreadFactory() {
+        ThreadFactory inner = Executors.defaultThreadFactory();
+        @Override
+        public Thread newThread(@NonNull Runnable r) {
+            Thread thread = inner.newThread(r);
+            thread.setPriority(2);
+            return thread;
+        }
+    };
 
     private final DownloadTask.Listener mDownloadTaskListener = new DownloadTask.Listener() {
 
@@ -248,8 +259,9 @@ public class DefaultDownloadService extends Service {
         database = new Database(dbFile, this);
 
         startHandlerThreads();
+        mExecutor = Executors.newFixedThreadPool(settings.maxConcurrentDownloads, executorThreadFactory);
 
-        mExecutor = Executors.newFixedThreadPool(settings.maxConcurrentDownloads);
+
 
         started = true;
     }

--- a/dtglib/src/main/java/com/kaltura/dtg/clear/HLSParser.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/clear/HLSParser.java
@@ -212,7 +212,7 @@ class HLSParser {
             if (!line.isEmpty() && line.charAt(0) != '#') {
                 lines[i] = Utils.getHashedFileName(line);
             }
-            Log.d(TAG, String.format("rename in playlist: '%s' ==> '%s'", line, lines[i]));
+//            Log.d(TAG, String.format("rename in playlist: '%s' ==> '%s'", line, lines[i]));
         }
         String modifiedData = TextUtils.join("\n", lines);
 
@@ -240,8 +240,8 @@ class HLSParser {
             URL segmentURL = new URL(variantURL, segment.url);
             File segmentFile = new File(targetDirectory, Utils.getHashedFileName(segment.url));
 
-            Log.d(TAG, String.format("rename in file: '%s' ==> '%s' (%s ==> %s)",
-                    segmentURL, segmentFile, segment.url, Utils.getHashedFileName(segment.url)));
+//            Log.d(TAG, String.format("rename in file: '%s' ==> '%s' (%s ==> %s)",
+//                    segmentURL, segmentFile, segment.url, Utils.getHashedFileName(segment.url)));
 
             downloadTasks.add(new DownloadTask(segmentURL, segmentFile));
         }


### PR DESCRIPTION
- When pausing an item, don't read tasks to memory - just count them.
- DownloadTask: only send HEAD request if the local file is already found.
