### PR TITLE
Make AppBuildConfig errors less intrusive

### DIFF
--- a/dtglib/src/main/java/com/kaltura/dtg/AppBuildConfig.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/AppBuildConfig.java
@@ -9,16 +9,21 @@ public class AppBuildConfig {
     public static boolean DEBUG;
 
     public static Object get(Context context, String fieldName) {
+        String className = context.getPackageName() + ".BuildConfig";
         try {
-            Class<?> clazz = Class.forName(context.getPackageName() + ".BuildConfig");
+            Class<?> clazz = Class.forName(className);
             Field field = clazz.getField(fieldName);
             return field.get(null);
+        } catch (ClassNotFoundException e) {
+            Log.e("AppBuildConfig", "Could not find class " + className + ". "
+                    + "Setting AppBuildConfig.DEBUG to false");
+            return null;
         } catch (Exception e) {
             Log.e("AppBuildConfig", "Error", e);
             return null;
         }
     }
-    
+
     public static void init(Context context) {
         Boolean debug = (Boolean) get(context, "DEBUG");
         DEBUG = debug != null ? debug : false;


### PR DESCRIPTION
Before, Kaltura DTG logged the whole stacktrace to the logcat and now it will only log a small error instead:
```
E/AppBuildConfig: Could not find class com.kaltura.dtgapp.queue2.BuildConfig. Setting AppBuildConfig.DEBUG to false
```

To reproduce this, you can set the `applicationId` to anything else in the samples.