### PR TITLE
Exclude unsupported tracks from the list

### DIFF
--- a/dtglib/src/main/java/com/kaltura/dtg/CodecSupport.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/CodecSupport.java
@@ -1,0 +1,76 @@
+package com.kaltura.dtg;
+
+import android.media.MediaCodecInfo;
+import android.media.MediaCodecList;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
+
+import com.kaltura.android.exoplayer.chunk.Format;
+import com.kaltura.android.exoplayer.util.MimeTypes;
+import com.kaltura.dtg.DownloadItem.TrackType;
+
+import java.util.HashMap;
+
+public class CodecSupport {
+
+    private static HashMap<TrackType, HashMap<String, Boolean>> cache = new HashMap<>();
+
+    static {
+        cache.put(TrackType.VIDEO, new HashMap<String, Boolean>());
+        cache.put(TrackType.AUDIO, new HashMap<String, Boolean>());
+    }
+
+    private static boolean isCodecSupportedInternal(String codec, TrackType type) {
+        String mimeType = type == TrackType.AUDIO ? MimeTypes.getAudioMediaMimeType(codec) :
+                                               MimeTypes.getVideoMediaMimeType(codec);
+
+        for (int i = 0, n = MediaCodecList.getCodecCount(); i < n; i++) {
+            final MediaCodecInfo codecInfo = MediaCodecList.getCodecInfoAt(i);
+            for (String s : codecInfo.getSupportedTypes()) {
+                if (s.equalsIgnoreCase(mimeType)) {
+                    // TODO: also verify the attributes
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean isCodecSupported(@NonNull String codec, @NonNull TrackType type) {
+
+        final HashMap<String, Boolean> typeCache = cache.get(type);
+        final Boolean cachedValue = typeCache.get(codec);
+        if (cachedValue != null) {
+            return cachedValue;
+        }
+
+        final boolean sup = isCodecSupportedInternal(codec, type);
+        typeCache.put(codec, sup);
+        return sup;
+    }
+
+    public static boolean isFormatSupported(@NonNull Format format, @Nullable TrackType type) {
+
+        if (type == TrackType.TEXT) {
+            return true;    // always supported
+        }
+
+        if (type == null) {
+            // type==null: HLS muxed track with a <video,audio> tuple
+            final String[] split = TextUtils.split(format.codecs, ",");
+            boolean result = true;
+            switch (split.length) {
+                case 0: return false;
+                case 2: result = isCodecSupported(split[1], TrackType.AUDIO);
+                // fallthrough
+                case 1: result &= isCodecSupported(split[0], TrackType.VIDEO);
+            }
+            return result;
+
+        } else {
+            return isCodecSupported(format.codecs, type);
+        }
+    }
+}

--- a/dtglib/src/main/java/com/kaltura/dtg/dash/DashDownloader.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/dash/DashDownloader.java
@@ -16,6 +16,7 @@ import com.kaltura.dtg.AbrDownloader;
 import com.kaltura.dtg.AssetFormat;
 import com.kaltura.dtg.BaseTrack;
 import com.kaltura.dtg.BuildConfig;
+import com.kaltura.dtg.CodecSupport;
 import com.kaltura.dtg.DownloadItem;
 import com.kaltura.dtg.DownloadItemImp;
 import com.kaltura.dtg.DownloadTask;
@@ -191,10 +192,15 @@ public class DashDownloader extends AbrDownloader {
                 }
 
                 Format format = representation.format;
+
+                if (!CodecSupport.isFormatSupported(format, type)) {
+                    continue;
+                }
+
                 DashTrack track = new DashTrack(type, format, adaptationIndex, representationIndex);
                 track.setHeight(format.height);
                 track.setWidth(format.width);
-                getAvailableTracksMap().get(type).add(track);
+                availableTracks.get(type).add(track);
             }
         }
     }

--- a/dtglib/src/main/java/com/kaltura/dtg/hls/HlsAsset.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/hls/HlsAsset.java
@@ -8,6 +8,7 @@ import com.kaltura.android.exoplayer.hls.HlsPlaylist;
 import com.kaltura.android.exoplayer.hls.HlsPlaylistParser;
 import com.kaltura.android.exoplayer.hls.Variant;
 import com.kaltura.dtg.BaseTrack;
+import com.kaltura.dtg.CodecSupport;
 import com.kaltura.dtg.DownloadItem.TrackType;
 import com.kaltura.dtg.Utils;
 
@@ -55,9 +56,11 @@ public class HlsAsset {
 
     private void parseVariants(List<Variant> variants, List<Track> trackList, TrackType trackType) {
         for (Variant variant : variants) {
-
-            final Track track = new Track(variant, trackType, masterUrl);
-            trackList.add(track);
+            // TODO: is this assumption (that VIDEO means the main content) correct?
+            if (CodecSupport.isFormatSupported(variant.format, trackType == TrackType.VIDEO ? null : trackType)) {
+                final Track track = new Track(variant, trackType, masterUrl);
+                trackList.add(track);
+            }
         }
     }
 


### PR DESCRIPTION
This is done by first converting the codec string (like `mp4a.40.2`) to a mime type (like `audio/mp4a-latm`), then querying Android's `MediaCodecInfo` for codecs that support the mime type.