### PR TITLE
Prevent mkdirs failures from crashing the app

### DIFF
--- a/dtgdemo/build.gradle
+++ b/dtgdemo/build.gradle
@@ -17,6 +17,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    lintOptions {
+        abortOnError false
+    }
 }
 
 repositories {

--- a/dtgdemo/build.gradle
+++ b/dtgdemo/build.gradle
@@ -26,9 +26,7 @@ repositories {
 dependencies {
     implementation project(':dtglib')
 
-//    implementation 'com.kaltura.playkit:playkit:3.5.0'
-    implementation 'com.kaltura:playkit-android:2d970f2'
-    implementation 'com.kaltura:playkit-android-providers:997877b'
+    implementation 'com.kaltura.playkit:playkit:3.5.0'
 
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support:support-v4:27.1.1'

--- a/dtgdemo/build.gradle
+++ b/dtgdemo/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 26
 
     defaultConfig {
         applicationId "com.kaltura.dtg.demo"
         minSdkVersion 17
-        targetSdkVersion 27
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }
@@ -28,6 +28,6 @@ dependencies {
 
     implementation 'com.kaltura.playkit:playkit:3.5.0'
 
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support:support-v4:27.1.1'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.android.support:support-v4:26.1.0'
 }

--- a/dtgdemo/src/main/java/com/kaltura/dtg/demo/MainActivity.java
+++ b/dtgdemo/src/main/java/com/kaltura/dtg/demo/MainActivity.java
@@ -483,30 +483,31 @@ public class MainActivity extends ListActivity {
             toast("NO NETWORK AVAILABLE");
         }
 
-        try {
-            contentManager = ContentManager.getInstance(this);
-        } catch (IOException e) {
-            e.printStackTrace();
-            toast("Failed to get ContentManager");
-            return;
-        }
+        contentManager = ContentManager.getInstance(this);
 
         contentManager.getSettings().defaultHlsAudioBitrateEstimation = DemoParams.defaultHlsAudioBitrateEstimation;
         contentManager.getSettings().applicationName = "MyApplication";
         contentManager.getSettings().maxConcurrentDownloads = 4;
         contentManager.getSettings().createNoMediaFileInDownloadsDir = true;
         contentManager.addDownloadStateListener(cmListener);
-        contentManager.start(new ContentManager.OnStartedListener() {
-            @Override
-            public void onStarted() {
-                for (DownloadItem item : contentManager.getDownloads(DownloadState.values())) {
-                    itemStateChanged(item);
-                }
 
-                setListAdapter(itemArrayAdapter);
-            }
-        });
-        
+        try {
+            contentManager.start(new ContentManager.OnStartedListener() {
+                @Override
+                public void onStarted() {
+                    for (DownloadItem item : contentManager.getDownloads(DownloadState.values())) {
+                        itemStateChanged(item);
+                    }
+
+                    setListAdapter(itemArrayAdapter);
+                }
+            });
+        } catch (IOException e) {
+            e.printStackTrace();
+            toast("Failed to get ContentManager");
+            return;
+        }
+
         localAssetsManager = new LocalAssetsManager(context);
         
         findViewById(R.id.download_control).setOnClickListener(new View.OnClickListener() {
@@ -520,12 +521,16 @@ public class MainActivity extends ListActivity {
                             public void onClick(DialogInterface dialog, int which) {
                                 switch (which) {
                                     case 0:
-                                        contentManager.start(new ContentManager.OnStartedListener() {
-                                            @Override
-                                            public void onStarted() {
-                                                toast("Service started");
-                                            }
-                                        });
+                                        try {
+                                            contentManager.start(new ContentManager.OnStartedListener() {
+                                                @Override
+                                                public void onStarted() {
+                                                    toast("Service started");
+                                                }
+                                            });
+                                        } catch (IOException e) {
+                                            e.printStackTrace();
+                                        }
                                         break;
                                     case 1:
                                         contentManager.stop();

--- a/dtgdemo/src/main/java/com/kaltura/dtg/demo/MainActivity.java
+++ b/dtgdemo/src/main/java/com/kaltura/dtg/demo/MainActivity.java
@@ -33,10 +33,10 @@ import com.kaltura.playkit.PKMediaFormat;
 import com.kaltura.playkit.PKMediaSource;
 import com.kaltura.playkit.PlayKitManager;
 import com.kaltura.playkit.Player;
+import com.kaltura.playkit.api.ovp.SimpleOvpSessionProvider;
+import com.kaltura.playkit.mediaproviders.base.OnMediaLoadCompletion;
+import com.kaltura.playkit.mediaproviders.ovp.KalturaOvpMediaProvider;
 import com.kaltura.playkit.player.MediaSupport;
-import com.kaltura.playkit.providers.api.ovp.SimpleOvpSessionProvider;
-import com.kaltura.playkit.providers.base.OnMediaLoadCompletion;
-import com.kaltura.playkit.providers.ovp.KalturaOvpMediaProvider;
 
 import java.io.File;
 import java.io.IOException;

--- a/dtgdemo/src/main/java/com/kaltura/dtg/demo/MainActivity.java
+++ b/dtgdemo/src/main/java/com/kaltura/dtg/demo/MainActivity.java
@@ -39,6 +39,7 @@ import com.kaltura.playkit.providers.base.OnMediaLoadCompletion;
 import com.kaltura.playkit.providers.ovp.KalturaOvpMediaProvider;
 
 import java.io.File;
+import java.io.IOException;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -481,7 +482,15 @@ public class MainActivity extends ListActivity {
         if (!isNetworkAvailable()) {
             toast("NO NETWORK AVAILABLE");
         }
-        contentManager = ContentManager.getInstance(this);
+
+        try {
+            contentManager = ContentManager.getInstance(this);
+        } catch (IOException e) {
+            e.printStackTrace();
+            toast("Failed to get ContentManager");
+            return;
+        }
+
         contentManager.getSettings().defaultHlsAudioBitrateEstimation = DemoParams.defaultHlsAudioBitrateEstimation;
         contentManager.getSettings().applicationName = "MyApplication";
         contentManager.getSettings().maxConcurrentDownloads = 4;
@@ -568,12 +577,18 @@ public class MainActivity extends ListActivity {
     }
 
     void addAndLoad(Item item) {
-        DownloadItem downloadItem = contentManager.createItem(item.getId(), item.getUrl());
-        downloadItem.loadMetadata();
-        itemStateChanged(downloadItem);
+        DownloadItem downloadItem = null;
+        try {
+            downloadItem = contentManager.createItem(item.getId(), item.getUrl());
+            downloadItem.loadMetadata();
+            itemStateChanged(downloadItem);
+        } catch (IOException e) {
+            toast("Failed to add item: " + e.toString());
+            e.printStackTrace();
+        }
     }
 
-    
+
     @Override
     protected void onListItemClick(ListView l, View v, int position, long id) {
         super.onListItemClick(l, v, position, id);

--- a/dtglib/src/main/java/com/kaltura/dtg/ContentManager.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/ContentManager.java
@@ -3,13 +3,14 @@ package com.kaltura.dtg;
 import android.content.Context;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 
 public abstract class ContentManager {
     private static final String VERSION_STRING = BuildConfig.VERSION_NAME;
     static final String CLIENT_TAG = "playkit-dtg/android-" + VERSION_STRING;
 
-    public static ContentManager getInstance(Context context) {
+    public static ContentManager getInstance(Context context) throws IOException {
         return ContentManagerImp.getInstance(context);
     }
 
@@ -88,7 +89,7 @@ public abstract class ContentManager {
      * @param contentURL
      * @return
      */
-    public abstract DownloadItem createItem(String itemId, String contentURL) throws IllegalStateException;
+    public abstract DownloadItem createItem(String itemId, String contentURL) throws IllegalStateException, IOException;
 
     /**
      * Remove item entirely. Deletes all files and db records.

--- a/dtglib/src/main/java/com/kaltura/dtg/ContentManager.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/ContentManager.java
@@ -10,7 +10,7 @@ public abstract class ContentManager {
     private static final String VERSION_STRING = BuildConfig.VERSION_NAME;
     static final String CLIENT_TAG = "playkit-dtg/android-" + VERSION_STRING;
 
-    public static ContentManager getInstance(Context context) throws IOException {
+    public static ContentManager getInstance(Context context) {
         return ContentManagerImp.getInstance(context);
     }
 
@@ -39,8 +39,9 @@ public abstract class ContentManager {
     /**
      * Start the download manager. Starts all downloads that were in IN_PROGRESS state when the
      * manager was stopped. Add listeners before calling this method.
+     * @throws IOException if an error has occurred when trying to prepare the storage.
      */
-    public abstract void start(OnStartedListener onStartedListener);
+    public abstract void start(OnStartedListener onStartedListener) throws IOException;
 
     /**
      * Stop the downloader. Stops all running downloads, but keep them in IN_PROGRESS state.

--- a/dtglib/src/main/java/com/kaltura/dtg/ContentManagerImp.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/ContentManagerImp.java
@@ -82,14 +82,16 @@ public class ContentManagerImp extends ContentManager {
     private DownloadRequestParams.Adapter adapter;
     private final Settings settings = new Settings();
 
-    private final File dataDir;
+    private File dataDir;
     private File downloadsDir;
-    private final File itemsDir;
+    private File itemsDir;
 
-    private ContentManagerImp(Context context) throws IOException {
+    private ContentManagerImp(Context context) {
         this.context = context.getApplicationContext();
+    }
 
-        File filesDir = this.context.getFilesDir();
+    private void prepareStorage() throws IOException {
+        File filesDir = context.getFilesDir();
         itemsDir = new File(filesDir, "dtg/items");
 
         // Create all directories
@@ -104,6 +106,7 @@ public class ContentManagerImp extends ContentManager {
             downloadsDir = new File(extFilesDir, "dtg/clear");
             Utils.mkdirsOrThrow(downloadsDir);
             if (settings.createNoMediaFileInDownloadsDir) {
+                //noinspection ResultOfMethodCallIgnored
                 new File(extFilesDir, ".nomedia").createNewFile();
             }
         } else {
@@ -111,7 +114,7 @@ public class ContentManagerImp extends ContentManager {
         }
     }
 
-    public static ContentManager getInstance(Context context) throws IOException {
+    public static ContentManager getInstance(Context context) {
         if (sInstance == null) {
             synchronized (ContentManager.class) {
                 if (sInstance == null) {
@@ -147,8 +150,11 @@ public class ContentManagerImp extends ContentManager {
     }
 
     @Override
-    public void start(final OnStartedListener onStartedListener) {
+    public void start(final OnStartedListener onStartedListener) throws IOException {
         Log.d(TAG, "start Content Manager");
+
+        prepareStorage();
+
         this.sessionId = UUID.randomUUID().toString();
         this.applicationName = ("".equals(settings.applicationName)) ? context.getPackageName() : settings.applicationName;
         this.adapter = new KalturaDownloadRequestAdapter(sessionId, applicationName);

--- a/dtglib/src/main/java/com/kaltura/dtg/Database.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/Database.java
@@ -93,8 +93,7 @@ class Database {
 
     Database(File dbFile, final Context context) {
 
-        final File externalFilesDir = context.getExternalFilesDir(null);
-        this.externalFilesDir = externalFilesDir != null ? externalFilesDir.getAbsolutePath() + "/" : null;
+        this.externalFilesDir = Storage.getExtFilesDir().getAbsolutePath();
 
         try {
             traceWriter = new BufferedWriter(new FileWriter(dbFile.getParent() + "/dbtrace.txt"));

--- a/dtglib/src/main/java/com/kaltura/dtg/DownloadService.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/DownloadService.java
@@ -43,8 +43,6 @@ public class DownloadService extends Service {
     private final LocalBinder localBinder = new LocalBinder();
     private Database database;
     private DownloadRequestParams.Adapter adapter;
-    private File downloadsDir;
-    private File dataDir;
     private boolean started;
     private boolean stopping;
     private DownloadStateListener downloadStateListener;
@@ -272,7 +270,7 @@ public class DownloadService extends Service {
         Log.d(TAG, "start()");
 
 
-        File dbFile = new File(dataDir, "downloads.db");
+        File dbFile = new File(Storage.getDataDir(), "downloads.db");
 
         database = new Database(dbFile, context);
 
@@ -340,7 +338,7 @@ public class DownloadService extends Service {
     private File getItemDataDir(String itemId) {
         assertStarted();
 
-        return new File(downloadsDir, "items/" + itemId + "/data");
+        return new File(Storage.getDownloadsDir(), "items/" + itemId + "/data");
     }
 
     private boolean isServiceStopped() {
@@ -503,11 +501,10 @@ public class DownloadService extends Service {
         itemCache.remove(itemId);
     }
 
-    private void deleteItemFiles(String item) {
-        String path = downloadsDir + "/items/" + item;
-        File file = new File(path);
+    private void deleteItemFiles(String itemId) {
+        File itemDir = new File(Storage.getDownloadsDir(), "items/" + itemId);
 
-        Utils.deleteRecursive(file);
+        Utils.deleteRecursive(itemDir);
     }
 
     /**
@@ -655,15 +652,12 @@ public class DownloadService extends Service {
         };
     }
 
-    void setInitParams(InitParams initParams) {
+    void setSettings(ContentManager.Settings settings) {
         if (started) {
             throw new IllegalStateException("Can't change settings after start");
         }
 
-        // Copy fields.
-        this.settings = initParams.settings.copy();
-        this.dataDir = initParams.dataDir;
-        this.downloadsDir = initParams.downloadsDir;
+        this.settings = settings;
     }
 
     class LocalBinder extends Binder {
@@ -761,18 +755,6 @@ public class DownloadService extends Service {
                 }
             }
             database.updateItemInfo(item, columns);
-        }
-    }
-
-    static class InitParams {
-        ContentManager.Settings settings;
-        File downloadsDir;
-        File dataDir;
-
-        InitParams(ContentManager.Settings settings, File downloadsDir, File dataDir) {
-            this.settings = settings;
-            this.downloadsDir = downloadsDir;
-            this.dataDir = dataDir;
         }
     }
 }

--- a/dtglib/src/main/java/com/kaltura/dtg/ServiceProxy.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/ServiceProxy.java
@@ -14,7 +14,7 @@ import java.util.List;
 class ServiceProxy {
 
     private static final String TAG = "ServiceProxy";
-    private final ContentManager.Settings settings;
+    private final DownloadService.InitParams initParams;
     private final Context context;
     private DownloadService service;
     private DownloadStateListener listener;
@@ -26,7 +26,7 @@ class ServiceProxy {
         public void onServiceConnected(ComponentName name, IBinder binder) {
             service = ((DownloadService.LocalBinder) binder).getService();
             service.setDownloadStateListener(listener);
-            service.setDownloadSettings(settings);
+            service.setInitParams(initParams);
             service.start();
             onStartedListener.onStarted();
         }
@@ -38,9 +38,9 @@ class ServiceProxy {
         }
     };
 
-    ServiceProxy(Context context, ContentManager.Settings settings) {
+    ServiceProxy(Context context, DownloadService.InitParams initParams) {
         this.context = context.getApplicationContext();
-        this.settings = settings;
+        this.initParams = initParams;
     }
 
     public void start(ContentManager.OnStartedListener startedListener) {
@@ -94,7 +94,7 @@ class ServiceProxy {
         return service.getDownloadedItemSize(itemId);
     }
 
-    public DownloadItem createItem(String itemId, String contentURL) {
+    public DownloadItem createItem(String itemId, String contentURL) throws Utils.DirectoryNotCreatableException {
         return service.createItem(itemId, contentURL);
     }
 

--- a/dtglib/src/main/java/com/kaltura/dtg/ServiceProxy.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/ServiceProxy.java
@@ -14,7 +14,7 @@ import java.util.List;
 class ServiceProxy {
 
     private static final String TAG = "ServiceProxy";
-    private final DownloadService.InitParams initParams;
+    private final ContentManager.Settings settings;
     private final Context context;
     private DownloadService service;
     private DownloadStateListener listener;
@@ -26,7 +26,7 @@ class ServiceProxy {
         public void onServiceConnected(ComponentName name, IBinder binder) {
             service = ((DownloadService.LocalBinder) binder).getService();
             service.setDownloadStateListener(listener);
-            service.setInitParams(initParams);
+            service.setSettings(settings);
             service.start();
             onStartedListener.onStarted();
         }
@@ -38,9 +38,9 @@ class ServiceProxy {
         }
     };
 
-    ServiceProxy(Context context, DownloadService.InitParams initParams) {
+    ServiceProxy(Context context, ContentManager.Settings settings) {
         this.context = context.getApplicationContext();
-        this.initParams = initParams;
+        this.settings = settings;
     }
 
     public void start(ContentManager.OnStartedListener startedListener) {

--- a/dtglib/src/main/java/com/kaltura/dtg/Storage.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/Storage.java
@@ -1,0 +1,59 @@
+package com.kaltura.dtg;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+class Storage {
+    private static File itemsDir;
+    private static File dataDir;
+    private static File downloadsDir;
+    private static File extFilesDir;
+
+    @NonNull
+    static File getExtFilesDir() {
+        return extFilesDir;
+    }
+
+    @NonNull
+    static File getItemsDir() {
+        return itemsDir;
+    }
+
+    @NonNull
+    static File getDataDir() {
+        return dataDir;
+    }
+
+    @NonNull
+    static File getDownloadsDir() {
+        return downloadsDir;
+    }
+
+    static void setup(Context context, ContentManager.Settings settings) throws IOException {
+        File filesDir = context.getFilesDir();
+        itemsDir = new File(filesDir, "dtg/items");
+
+        // Create all directories
+        Utils.mkdirsOrThrow(filesDir);
+        Utils.mkdirsOrThrow(itemsDir);
+
+        dataDir = new File(filesDir, "dtg/clear");
+        Utils.mkdirsOrThrow(dataDir);
+
+        extFilesDir = context.getExternalFilesDir(null);
+        if (extFilesDir == null) {
+            throw new FileNotFoundException("No external files dir, can't continue");
+        }
+
+        downloadsDir = new File(extFilesDir, "dtg/clear");
+        Utils.mkdirsOrThrow(downloadsDir);
+        if (settings.createNoMediaFileInDownloadsDir) {
+            //noinspection ResultOfMethodCallIgnored
+            new File(extFilesDir, ".nomedia").createNewFile();
+        }
+    }
+}

--- a/dtglib/src/main/java/com/kaltura/dtg/Utils.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/Utils.java
@@ -282,12 +282,10 @@ public class Utils {
         return dir.mkdirs() || dir.isDirectory();
     }
 
-    public static void mkdirsOrThrow(File dir) {
-        if (dir.mkdirs() || dir.isDirectory()) {
-            return;
+    public static void mkdirsOrThrow(File dir) throws DirectoryNotCreatableException {
+        if (!mkdirs(dir)) {
+            throw new DirectoryNotCreatableException(dir);
         }
-
-        throw new IllegalStateException("Can't create directory " + dir);
     }
 
     public static byte[] readFile(File file, int byteLimit) throws IOException {
@@ -297,5 +295,15 @@ public class Utils {
 
     public static long estimateTrackSize(int trackBitrate, long durationMS) {
         return trackBitrate * durationMS / 1000 / 8;    // first multiply, then divide
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public static class DirectoryNotCreatableException extends IOException {
+
+        private static final long serialVersionUID = -1369279756939511377L;
+
+        private DirectoryNotCreatableException(File dir) {
+            super("Can't create directory " + dir);
+        }
     }
 }


### PR DESCRIPTION
Instead, for the global directories:
- All of the global dirs are created in ContentManager.start()
- `start()` throws `DirectoryNotCreatableException` (extends IOException) if it fails to create a directory
- The app has to catch a potential `IOException` when it calls `start()`.

If directory creation fails, DTG can't do anything (create db, download, etc). It's not known what causes mkdir to fail, but reports say that **reinstalling** the app fixes it.

Makedirs failures per item now call DownloadStateListener.onDownloadError().

## Breaking change
`ContentManager.start()` throws an IOException that the app has to catch. 
