### PR TITLE
FEM-2152: Disk space checking

### DIFF
--- a/dtgdemo/src/main/java/com/kaltura/dtg/demo/MainActivity.java
+++ b/dtgdemo/src/main/java/com/kaltura/dtg/demo/MainActivity.java
@@ -261,7 +261,7 @@ class Item {
 
 
 public class MainActivity extends ListActivity {
-    
+
     private static final String TAG = "MainActivity";
     private ContentManager contentManager;
     private LocalAssetsManager localAssetsManager;
@@ -300,7 +300,14 @@ public class MainActivity extends ListActivity {
         }
 
         @Override
-        public void onDownloadFailure(DownloadItem item, Exception error) {
+        public void onDownloadFailure(final DownloadItem item, final Exception error) {
+            Log.d(TAG, "onDownloadFailure: " + item);
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    Toast.makeText(context, "Download of " + item.getItemId() + " has failed: " + error.getMessage(), Toast.LENGTH_LONG).show();
+                }
+            });
             itemStateChanged(item);
         }
 
@@ -524,10 +531,11 @@ public class MainActivity extends ListActivity {
 
         contentManager = ContentManager.getInstance(this);
 
-        contentManager.getSettings().defaultHlsAudioBitrateEstimation = DemoParams.defaultHlsAudioBitrateEstimation;
-        contentManager.getSettings().applicationName = "MyApplication";
-        contentManager.getSettings().maxConcurrentDownloads = 4;
-        contentManager.getSettings().createNoMediaFileInDownloadsDir = true;
+        final ContentManager.Settings settings = contentManager.getSettings();
+        settings.defaultHlsAudioBitrateEstimation = DemoParams.defaultHlsAudioBitrateEstimation;
+        settings.applicationName = "MyApplication";
+        settings.maxConcurrentDownloads = 4;
+        settings.createNoMediaFileInDownloadsDir = true;
         contentManager.addDownloadStateListener(cmListener);
 
         try {

--- a/dtglib/src/main/java/com/kaltura/dtg/ContentManager.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/ContentManager.java
@@ -140,6 +140,7 @@ public abstract class ContentManager {
         public String applicationName = "";
         public boolean createNoMediaFileInDownloadsDir = true;
         public int defaultHlsAudioBitrateEstimation = 64000;
+        public long freeDiskSpaceRequiredBytes = 400 * 1024 * 1024; // default 400MB
 
         Settings copy() {
             try {

--- a/dtglib/src/main/java/com/kaltura/dtg/Database.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/Database.java
@@ -341,7 +341,7 @@ class Database {
         trace("markTaskAsComplete done", downloadTask.itemId, downloadTask.taskId);
     }
 
-    synchronized DownloadItemImp findItemInDB(String itemId) {
+    synchronized @Nullable DownloadItemImp findItemInDB(String itemId) {
 
         trace("findItemInDB", itemId);
 

--- a/dtglib/src/main/java/com/kaltura/dtg/DownloadService.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/DownloadService.java
@@ -9,6 +9,7 @@ import android.os.Binder;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.IBinder;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
@@ -174,7 +175,7 @@ public class DownloadService extends Service {
         }
     }
 
-    private void cancelItemWithError(final DownloadItemImp item, final Exception stopError) {
+    private void cancelItemWithError(@NonNull final DownloadItemImp item, final Exception stopError) {
         itemCache.updateItemState(item, DownloadState.FAILED);
 
         futureMap.cancelItem(item.getItemId());
@@ -404,7 +405,7 @@ public class DownloadService extends Service {
         database.addTracks(item, availableTracks, selectedTracks);
     }
 
-    DownloadState startDownload(final DownloadItemImp item) {
+    DownloadState startDownload(@NonNull final DownloadItemImp item) {
         assertStarted();
 
         if (Storage.isLowDiskSpace(settings.freeDiskSpaceRequiredBytes)) {
@@ -479,7 +480,7 @@ public class DownloadService extends Service {
         }
     }
 
-    void resumeDownload(DownloadItemImp item) {
+    void resumeDownload(@NonNull DownloadItemImp item) {
         assertStarted();
 
         // resume should be considered as download start
@@ -520,7 +521,7 @@ public class DownloadService extends Service {
      *
      * @return An item identified by itemId, or null if not found.
      */
-    DownloadItemImp findItem(String itemId) {
+    @Nullable DownloadItemImp findItem(String itemId) {
         assertStarted();
 
         return itemCache.get(itemId);
@@ -643,7 +644,9 @@ public class DownloadService extends Service {
                     try {
                         if (Storage.isLowDiskSpace(settings.freeDiskSpaceRequiredBytes)) {
                             final DownloadItemImp item = itemCache.get(itemId);
-                            cancelItemWithError(item, new Utils.LowDiskSpaceException());
+                            if (item != null) {
+                                cancelItemWithError(item, new Utils.LowDiskSpaceException());
+                            }
                             return null;
                         }
                         task.download();
@@ -716,7 +719,7 @@ public class DownloadService extends Service {
             });
         }
 
-        private DownloadItemImp get(String itemId) {
+        private @Nullable DownloadItemImp get(String itemId) {
             DownloadItemImp item = cache.get(itemId);
             if (item != null) {
                 itemLastUseTime.put(itemId, elapsedRealtime());

--- a/dtglib/src/main/java/com/kaltura/dtg/ServiceProxy.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/ServiceProxy.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.IBinder;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
@@ -78,7 +79,7 @@ class ServiceProxy {
         service.pauseDownload((DownloadItemImp) item);
     }
 
-    public void resumeDownload(DownloadItem item) {
+    public void resumeDownload(@NonNull DownloadItem item) {
         service.resumeDownload((DownloadItemImp) item);
     }
 

--- a/dtglib/src/main/java/com/kaltura/dtg/Storage.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/Storage.java
@@ -8,6 +8,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 
 class Storage {
+    private static long REQUIRED_DATA_PARTITION_SIZE_BYTES = 200 * 1024 * 1024;
     private static File itemsDir;
     private static File dataDir;
     private static File downloadsDir;
@@ -31,6 +32,12 @@ class Storage {
     @NonNull
     static File getDownloadsDir() {
         return downloadsDir;
+    }
+
+    static boolean isLowDiskSpace(long requiredBytes) {
+        final long downloadsDirFreeSpace = downloadsDir.getFreeSpace();
+        final long dataDirFreeSpace = dataDir.getFreeSpace();
+        return downloadsDirFreeSpace < requiredBytes || dataDirFreeSpace < REQUIRED_DATA_PARTITION_SIZE_BYTES;
     }
 
     static void setup(Context context, ContentManager.Settings settings) throws IOException {

--- a/dtglib/src/main/java/com/kaltura/dtg/Utils.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/Utils.java
@@ -305,11 +305,15 @@ public class Utils {
 
     @SuppressWarnings("WeakerAccess")
     public static class DirectoryNotCreatableException extends IOException {
-
-        private static final long serialVersionUID = -1369279756939511377L;
-
         private DirectoryNotCreatableException(File dir) {
             super("Can't create directory " + dir);
+        }
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public static class LowDiskSpaceException extends IOException {
+        LowDiskSpaceException() {
+            super("Not enough disk space available");
         }
     }
 


### PR DESCRIPTION
If there's not enough space when startDownload() is called, the item state is set to FAILED and the download listener is called: `onDownloadFailure(item, new Utils.LowDiskSpaceException())`.
Disk space is also checked before starting any DownloadTask (chunk).