### PR TITLE
Replace legacy support lib with granular dependency

### DIFF
--- a/dtglib/build.gradle
+++ b/dtglib/build.gradle
@@ -30,7 +30,7 @@ tasks.withType(Javadoc) {
 }
 
 dependencies {
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.annotation:annotation:1.1.0'
 }
 
 // build a jar with source files


### PR DESCRIPTION
There should be no need to pull in the whole `androidx.legacy:legacy-support-v4:1.0.0` since only annotations are used.