### PR TITLE
FEM-2795 -Expose ability to set a download adapter by download settings instead of having only default KalturaDownloadRequestAdapter 

### DIFF
--- a/dtglib/src/main/java/com/kaltura/dtg/ContentManager.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/ContentManager.java
@@ -141,6 +141,7 @@ public abstract class ContentManager {
         public boolean createNoMediaFileInDownloadsDir = true;
         public int defaultHlsAudioBitrateEstimation = 64000;
         public long freeDiskSpaceRequiredBytes = 400 * 1024 * 1024; // default 400MB
+        public DownloadRequestParams.Adapter downloadRequestAdapter;
         public DownloadRequestParams.Adapter chunksUrlAdapter;
 
         Settings copy() {

--- a/dtglib/src/main/java/com/kaltura/dtg/ContentManagerImp.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/ContentManagerImp.java
@@ -128,8 +128,8 @@ public class ContentManagerImp extends ContentManager {
         Storage.setup(context, settings);
 
         this.sessionId = UUID.randomUUID().toString();
-        this.applicationName = ("".equals(settings.applicationName)) ? context.getPackageName() : settings.applicationName;
-        this.adapter = new KalturaDownloadRequestAdapter(sessionId, applicationName);
+        this.applicationName = (TextUtils.isEmpty(settings.applicationName)) ? context.getPackageName() : settings.applicationName;
+        this.adapter = (settings.downloadRequestAdapter != null) ? settings.downloadRequestAdapter:  new KalturaDownloadRequestAdapter(sessionId, applicationName);
         this.chunksAdapter = settings.chunksUrlAdapter;
 
         if (started) {

--- a/dtglib/src/main/java/com/kaltura/dtg/ContentManagerImp.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/ContentManagerImp.java
@@ -129,7 +129,7 @@ public class ContentManagerImp extends ContentManager {
 
         this.sessionId = UUID.randomUUID().toString();
         this.applicationName = (TextUtils.isEmpty(settings.applicationName)) ? context.getPackageName() : settings.applicationName;
-        this.adapter = (settings.downloadRequestAdapter != null) ? settings.downloadRequestAdapter:  new KalturaDownloadRequestAdapter(sessionId, applicationName);
+        this.adapter = (settings.downloadRequestAdapter != null) ? settings.downloadRequestAdapter : new KalturaDownloadRequestAdapter(sessionId, applicationName);
         this.chunksAdapter = settings.chunksUrlAdapter;
 
         if (started) {

--- a/dtglib/src/main/java/com/kaltura/dtg/DownloadService.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/DownloadService.java
@@ -9,7 +9,6 @@ import android.os.Binder;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.IBinder;
-import android.text.TextUtils;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -43,7 +42,6 @@ public class DownloadService extends Service {
     private final Context context;  // allow mocking
     private final LocalBinder localBinder = new LocalBinder();
     private Database database;
-    private DownloadRequestParams.Adapter adapter;
     private boolean started;
     private boolean stopping;
     private DownloadStateListener downloadStateListener;


### PR DESCRIPTION
add ability to give propriety downloadRequestAdapter from type KalturaDownloadRequestAdapter  to the download settings object
this will give apps ability to configure their own Adapter.

Example:

```
        DownloadRequestParams.Adapter myAdapter = new DownloadRequestParams.Adapter() {
            @Override
            public DownloadRequestParams adapt(DownloadRequestParams requestParams) {
            final Uri.Builder builder = requestParams.url.buildUpon();
                //   Logic

                return new DownloadRequestParams(builder.build(), requestParams.headers);
            }
        };
        contentManager.getSettings().downloadRequestAdapter = myAdapter;
        
```

```
        contentManager.getSettings().downloadRequestAdapter = new 
KalturaDownloadRequestAdapter("AAA", "BBBB");
```
