### PR TITLE
FEM-2840 - add NPE  protection in catch due to optional bug in Locale getISO3Language 

### DIFF
--- a/dtglib/src/main/java/com/kaltura/dtg/exoparser/util/Util.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/exoparser/util/Util.java
@@ -299,7 +299,7 @@ public final class Util {
   public static @Nullable String normalizeLanguageCode(@Nullable String language) {
     try {
       return language == null ? null : new Locale(language).getISO3Language();
-    } catch (MissingResourceException e) {
+    } catch (MissingResourceException| NullPointerException e) {
       return toLowerInvariant(language);
     }
   }

--- a/dtglib/src/main/java/com/kaltura/dtg/exoparser/util/Util.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/exoparser/util/Util.java
@@ -299,7 +299,7 @@ public final class Util {
   public static @Nullable String normalizeLanguageCode(@Nullable String language) {
     try {
       return language == null ? null : new Locale(language).getISO3Language();
-    } catch (MissingResourceException| NullPointerException e) {
+    } catch (MissingResourceException | NullPointerException e) {
       return toLowerInvariant(language);
     }
   }


### PR DESCRIPTION
when given lang str more than 11 letters