### PR TITLE
FEC-10137 ContentManager fails to parse HLS master playlists with a query string in URL

### DIFF
--- a/dtglib/src/main/java/com/kaltura/dtg/Utils.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/Utils.java
@@ -330,8 +330,8 @@ public class Utils {
         return uri.toString();
     }
 
-    private static Uri removeQueryParam(Uri trackUri) {
-        return trackUri.buildUpon().clearQuery().build();
+    private static Uri removeQueryParam(Uri uri) {
+        return uri.buildUpon().clearQuery().build();
     }
 
     public static boolean mkdirs(File dir) {

--- a/dtglib/src/main/java/com/kaltura/dtg/Utils.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/Utils.java
@@ -316,12 +316,22 @@ public class Utils {
         }
 
         // resolve with baseUrl
-        final Uri trackUri = Uri.parse(baseUrl);
+        Uri trackUri = Uri.parse(baseUrl);
+        String uriQueryParam = uri.getEncodedQuery();
+        String trackUriQueryParam = trackUri.getEncodedQuery();
+        if (!TextUtils.isEmpty(uriQueryParam) && !TextUtils.isEmpty(trackUriQueryParam)) {
+            trackUri = removeQueryParam(trackUri);
+        }
+
         final List<String> pathSegments = new ArrayList<>(trackUri.getPathSegments());
         pathSegments.remove(pathSegments.size() - 1);
         final String pathWithoutLastSegment = TextUtils.join("/", pathSegments);
         uri = trackUri.buildUpon().encodedPath(pathWithoutLastSegment).appendEncodedPath(maybeRelative).build();
         return uri.toString();
+    }
+
+    private static Uri removeQueryParam(Uri trackUri) {
+        return trackUri.buildUpon().clearQuery().build();
     }
 
     public static boolean mkdirs(File dir) {

--- a/dtglib/src/main/java/com/kaltura/dtg/Utils.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/Utils.java
@@ -307,27 +307,28 @@ public class Utils {
     }
 
     public static String resolveUrl(String baseUrl, String maybeRelative) {
-        if (maybeRelative == null) {
+        if (maybeRelative == null || baseUrl == null) {
             return null;
         }
-        Uri uri = Uri.parse(maybeRelative);
-        if (uri.isAbsolute()) {
+        Uri maybeRelativeUri = Uri.parse(maybeRelative);
+        if (maybeRelativeUri.isAbsolute()) {
             return maybeRelative;
         }
 
         // resolve with baseUrl
-        Uri trackUri = Uri.parse(baseUrl);
-        String uriQueryParam = uri.getEncodedQuery();
-        String trackUriQueryParam = trackUri.getEncodedQuery();
-        if (!TextUtils.isEmpty(uriQueryParam) && !TextUtils.isEmpty(trackUriQueryParam)) {
-            trackUri = removeQueryParam(trackUri);
+        Uri baseUrlUri = Uri.parse(baseUrl);
+        String baseUriQueryParam = baseUrlUri.getEncodedQuery();
+        String maybeRelativeQueryParam = maybeRelativeUri.getEncodedQuery();
+
+        if (!TextUtils.isEmpty(maybeRelativeQueryParam) && !TextUtils.isEmpty(baseUriQueryParam)) {
+            baseUrlUri = removeQueryParam(baseUrlUri);
         }
 
-        final List<String> pathSegments = new ArrayList<>(trackUri.getPathSegments());
+        final List<String> pathSegments = new ArrayList<>(baseUrlUri.getPathSegments());
         pathSegments.remove(pathSegments.size() - 1);
         final String pathWithoutLastSegment = TextUtils.join("/", pathSegments);
-        uri = trackUri.buildUpon().encodedPath(pathWithoutLastSegment).appendEncodedPath(maybeRelative).build();
-        return uri.toString();
+        maybeRelativeUri = baseUrlUri.buildUpon().encodedPath(pathWithoutLastSegment).appendEncodedPath(maybeRelative).build();
+        return maybeRelativeUri.toString();
     }
 
     private static Uri removeQueryParam(Uri uri) {


### PR DESCRIPTION
Issue: 
For HLS media, if master url has query param and segment has relative path then we were appending both the query params in downloadable url.
Solution: We are checking if both master and segment has query param then we are removing query params from master and then as per the current logic, master url will be appended with segment identifier.