### PR TITLE
FEC-10618 API to cancel metadata loading

### DIFF
--- a/dtgdemo/src/main/java/com/kaltura/dtg/demo/MainActivity.java
+++ b/dtgdemo/src/main/java/com/kaltura/dtg/demo/MainActivity.java
@@ -9,8 +9,6 @@ import android.net.NetworkInfo;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.SystemClock;
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
@@ -19,6 +17,9 @@ import android.widget.ArrayAdapter;
 import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 
 import com.google.android.gms.security.ProviderInstaller;
 import com.kaltura.dtg.ContentManager;
@@ -38,10 +39,10 @@ import com.kaltura.playkit.player.AudioTrack;
 import com.kaltura.playkit.player.BaseTrack;
 import com.kaltura.playkit.player.PKTracks;
 import com.kaltura.playkit.player.TextTrack;
+import com.kaltura.playkit.providers.api.SimpleSessionProvider;
 import com.kaltura.playkit.providers.api.phoenix.APIDefines;
 import com.kaltura.playkit.providers.ott.PhoenixMediaProvider;
 import com.kaltura.playkit.providers.ovp.KalturaOvpMediaProvider;
-import com.kaltura.playkit.providers.api.SimpleSessionProvider;
 
 import java.io.File;
 import java.io.IOException;
@@ -57,7 +58,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static com.kaltura.playkit.player.MediaSupport.*;
+import static com.kaltura.playkit.player.MediaSupport.initializeDrm;
 
 class DemoParams {
     //    static int forceReducedLicenseDurationSeconds = 600;
@@ -207,7 +208,7 @@ class ItemLoader {
         // Using OVP provider for simplicity
 //        items.addAll(loadOVPItems(2222401, "1_q81a5nbp", "0_3cb7ganx"));
         // Using Phoenix provider for simplicity
-        items.addAll(loadOTTItems("https://api-preprod.ott.kaltura.com/v5_1_0/api_v3/", 198, "",  "Mobile_Devices_Main_HD_Dash", "480989"));
+        //  items.addAll(loadOTTItems("https://api-preprod.ott.kaltura.com/v5_1_0/api_v3/", 198, "",  "Mobile_Devices_Main_HD_Dash", "480989"));
 
         // For simple cases (no DRM), no need for MediaSource.
         //noinspection CollectionAddAllCanBeReplacedWithConstructor
@@ -410,8 +411,11 @@ public class MainActivity extends ListActivity {
             itemStateChanged(item);
 
             if (error != null) {
+                Log.e(TAG, " onDownloadMetadata" + error.toString());
                 toast(error.toString());
                 return;
+            } else {
+                Log.e(TAG, " onDownloadMetadata event came" + item.getItemId());
             }
 
             final List<DownloadItem.Track> tracks = new ArrayList<>();
@@ -733,6 +737,13 @@ public class MainActivity extends ListActivity {
         try {
             downloadItem = contentManager.createItem(item.getId(), item.getUrl());
             downloadItem.loadMetadata();
+            // new Handler().postDelayed(() -> downloadItem.cancelMetadata(item.getId()), 500);
+            //downloadItem.cancelMetadata(item.getId());
+            Log.i(TAG, "ITEM ADDED: " + item.getId());
+
+//            if (item.getId().equals("sintel-short-dash")) {
+//                new Handler().postDelayed(() -> downloadItem.cancelMetadata(item.getId()), 400);
+//            }
             itemStateChanged(downloadItem);
         } catch (IllegalArgumentException e) {
             toast("Failed to add item: " + e.toString());
@@ -746,13 +757,18 @@ public class MainActivity extends ListActivity {
         }
     }
 
-
     @Override
     protected void onListItemClick(ListView l, View v, int position, long id) {
         super.onListItemClick(l, v, position, id);
 
         ListAdapter adapter = l.getAdapter();
         final Item item = (Item) adapter.getItem(position);
+//        final Item item1 = (Item) adapter.getItem(position+1);
+//        final Item item2 = (Item) adapter.getItem(position+2);
+//        final Item item3 = (Item) adapter.getItem(position+3);
+//        final Item item4 = (Item) adapter.getItem(position+4);
+//        final Item item5 = (Item) adapter.getItem(position+5);
+//        final Item item6 = (Item) adapter.getItem(position+6);
         Log.d(TAG, "Clicked " + item);
 
         //DownloadState state = null;
@@ -779,6 +795,12 @@ public class MainActivity extends ListActivity {
 
                         case add:
                             addAndLoad(item);
+//                            addAndLoad(item1);
+//                            addAndLoad(item2);
+//                            addAndLoad(item3);
+//                            addAndLoad(item4);
+//                            addAndLoad(item5);
+//                            addAndLoad(item6);
                             break;
                         case start:
                             contentManager.findItem(item.getId()).startDownload();

--- a/dtgdemo/src/main/java/com/kaltura/dtg/demo/MainActivity.java
+++ b/dtgdemo/src/main/java/com/kaltura/dtg/demo/MainActivity.java
@@ -9,6 +9,8 @@ import android.net.NetworkInfo;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.SystemClock;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
@@ -17,9 +19,6 @@ import android.widget.ArrayAdapter;
 import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.Toast;
-
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 
 import com.google.android.gms.security.ProviderInstaller;
 import com.kaltura.dtg.ContentManager;
@@ -39,10 +38,10 @@ import com.kaltura.playkit.player.AudioTrack;
 import com.kaltura.playkit.player.BaseTrack;
 import com.kaltura.playkit.player.PKTracks;
 import com.kaltura.playkit.player.TextTrack;
-import com.kaltura.playkit.providers.api.SimpleSessionProvider;
 import com.kaltura.playkit.providers.api.phoenix.APIDefines;
 import com.kaltura.playkit.providers.ott.PhoenixMediaProvider;
 import com.kaltura.playkit.providers.ovp.KalturaOvpMediaProvider;
+import com.kaltura.playkit.providers.api.SimpleSessionProvider;
 
 import java.io.File;
 import java.io.IOException;
@@ -58,7 +57,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static com.kaltura.playkit.player.MediaSupport.initializeDrm;
+import static com.kaltura.playkit.player.MediaSupport.*;
 
 class DemoParams {
     //    static int forceReducedLicenseDurationSeconds = 600;
@@ -208,7 +207,7 @@ class ItemLoader {
         // Using OVP provider for simplicity
 //        items.addAll(loadOVPItems(2222401, "1_q81a5nbp", "0_3cb7ganx"));
         // Using Phoenix provider for simplicity
-        //  items.addAll(loadOTTItems("https://api-preprod.ott.kaltura.com/v5_1_0/api_v3/", 198, "",  "Mobile_Devices_Main_HD_Dash", "480989"));
+        items.addAll(loadOTTItems("https://api-preprod.ott.kaltura.com/v5_1_0/api_v3/", 198, "",  "Mobile_Devices_Main_HD_Dash", "480989"));
 
         // For simple cases (no DRM), no need for MediaSource.
         //noinspection CollectionAddAllCanBeReplacedWithConstructor
@@ -411,11 +410,8 @@ public class MainActivity extends ListActivity {
             itemStateChanged(item);
 
             if (error != null) {
-                Log.e(TAG, " onDownloadMetadata" + error.toString());
                 toast(error.toString());
                 return;
-            } else {
-                Log.e(TAG, " onDownloadMetadata event came" + item.getItemId());
             }
 
             final List<DownloadItem.Track> tracks = new ArrayList<>();
@@ -737,13 +733,6 @@ public class MainActivity extends ListActivity {
         try {
             downloadItem = contentManager.createItem(item.getId(), item.getUrl());
             downloadItem.loadMetadata();
-            // new Handler().postDelayed(() -> downloadItem.cancelMetadata(item.getId()), 500);
-            //downloadItem.cancelMetadata(item.getId());
-            Log.i(TAG, "ITEM ADDED: " + item.getId());
-
-//            if (item.getId().equals("sintel-short-dash")) {
-//                new Handler().postDelayed(() -> downloadItem.cancelMetadata(item.getId()), 400);
-//            }
             itemStateChanged(downloadItem);
         } catch (IllegalArgumentException e) {
             toast("Failed to add item: " + e.toString());
@@ -757,18 +746,13 @@ public class MainActivity extends ListActivity {
         }
     }
 
+
     @Override
     protected void onListItemClick(ListView l, View v, int position, long id) {
         super.onListItemClick(l, v, position, id);
 
         ListAdapter adapter = l.getAdapter();
         final Item item = (Item) adapter.getItem(position);
-//        final Item item1 = (Item) adapter.getItem(position+1);
-//        final Item item2 = (Item) adapter.getItem(position+2);
-//        final Item item3 = (Item) adapter.getItem(position+3);
-//        final Item item4 = (Item) adapter.getItem(position+4);
-//        final Item item5 = (Item) adapter.getItem(position+5);
-//        final Item item6 = (Item) adapter.getItem(position+6);
         Log.d(TAG, "Clicked " + item);
 
         //DownloadState state = null;
@@ -795,12 +779,6 @@ public class MainActivity extends ListActivity {
 
                         case add:
                             addAndLoad(item);
-//                            addAndLoad(item1);
-//                            addAndLoad(item2);
-//                            addAndLoad(item3);
-//                            addAndLoad(item4);
-//                            addAndLoad(item5);
-//                            addAndLoad(item6);
                             break;
                         case start:
                             contentManager.findItem(item.getId()).startDownload();

--- a/dtglib/src/main/java/com/kaltura/dtg/Database.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/Database.java
@@ -260,7 +260,11 @@ class Database {
 //                            Log.d(TAG, "Warning: task not added:" + task.targetFile);
                     }
                 } catch (SQLException e) {
-                    Log.e(TAG, "Failed to INSERT task: " + task.targetFile, e);
+                    if (!Thread.currentThread().isInterrupted()) {
+                        Log.e(TAG, "Failed to INSERT task: " + task.targetFile, e);
+                    } else {
+                        //Log.d(TAG, "Thread Interrupted in Database addDownloadTasksToDB");
+                    }
                 }
             }
             return true;
@@ -616,8 +620,12 @@ class Database {
                 try {
                     db.insertOrThrow(TBL_TRACK, null, values);
                 } catch (SQLiteConstraintException e) {
-                    Log.w(TAG, "Insert failed", e);
-                    Log.w(TAG, "execute: itemId=" + item.getItemId() + " rel=" + track.getRelativeId());
+                    if (!Thread.currentThread().isInterrupted()) {
+                        Log.w(TAG, "Insert failed", e);
+                        Log.w(TAG, "execute: itemId=" + item.getItemId() + " rel=" + track.getRelativeId());
+                    } else {
+                        //Log.d(TAG, "Thread Interrupted in Database addTracks");
+                    }
                 }
             }
 

--- a/dtglib/src/main/java/com/kaltura/dtg/Database.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/Database.java
@@ -9,10 +9,11 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.net.Uri;
 import android.os.SystemClock;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/dtglib/src/main/java/com/kaltura/dtg/DownloadItem.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/DownloadItem.java
@@ -25,7 +25,7 @@ public interface DownloadItem {
 
     void loadMetadata();
 
-    void cancelMetadata(String itemId);
+    void cancelMetadataLoading(String itemId);
 
     void pauseDownload();
 

--- a/dtglib/src/main/java/com/kaltura/dtg/DownloadItem.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/DownloadItem.java
@@ -25,6 +25,8 @@ public interface DownloadItem {
 
     void loadMetadata();
 
+    void cancelMetadata(String itemId);
+
     void pauseDownload();
 
     long getAddedTime();

--- a/dtglib/src/main/java/com/kaltura/dtg/DownloadItemImp.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/DownloadItemImp.java
@@ -145,8 +145,8 @@ public class DownloadItemImp implements DownloadItem {
     }
 
     @Override
-    public void cancelMetadata(String itemId) {
-        service.cancelMetadata(itemId);
+    public void cancelMetadataLoading(String itemId) {
+        service.cancelMetadataLoading(itemId);
     }
 
     @Override

--- a/dtglib/src/main/java/com/kaltura/dtg/DownloadItemImp.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/DownloadItemImp.java
@@ -145,6 +145,11 @@ public class DownloadItemImp implements DownloadItem {
     }
 
     @Override
+    public void cancelMetadata(String itemId) {
+        service.cancelMetadata(itemId);
+    }
+
+    @Override
     public void pauseDownload() {
         service.pauseDownload(this);
     }

--- a/dtglib/src/main/java/com/kaltura/dtg/DownloadService.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/DownloadService.java
@@ -360,7 +360,7 @@ public class DownloadService extends Service {
      * Cancel the In progress or queued Item while downloading the Metadata
      * @param itemId Item to be deleted
      */
-    void cancelMetadata(String itemId) {
+    void cancelMetadataLoading(String itemId) {
         DownloadItemImp item = findItem(itemId);
         if (item != null) {
             if (metaDataDownloadExecutorService != null && metaDataDownloadMap.containsKey(item.getItemId())) {

--- a/dtglib/src/main/java/com/kaltura/dtg/DownloadService.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/DownloadService.java
@@ -373,7 +373,7 @@ public class DownloadService extends Service {
                 }
             }
         } else {
-            Log.w(TAG, "Ignoring cancelMetadata as it can not be done on invalid item.");
+            Log.w(TAG, "Ignoring cancelMetadata loading as it can not be done on invalid item.");
         }
     }
 

--- a/dtglib/src/main/java/com/kaltura/dtg/DownloadService.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/DownloadService.java
@@ -373,7 +373,7 @@ public class DownloadService extends Service {
                 }
             }
         } else {
-            Log.w(TAG, "Ignoring cancelMetadata loading as it can not be done on invalid item.");
+            Log.w(TAG, "Can't cancel metadata loading as it can not be done on invalid item.");
         }
     }
 

--- a/dtglib/src/main/java/com/kaltura/dtg/DownloadService.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/DownloadService.java
@@ -426,6 +426,11 @@ public class DownloadService extends Service {
 
     DownloadState startDownload(@NonNull final DownloadItemImp item) {
         assertStarted();
+
+        if (removedItems.contains(item.getItemId())) {
+            throw new IllegalStateException("Can't start download on deleted item");
+        }
+
         removeItemFromEventStateMap(item.getItemId());
 
         if (Storage.isLowDiskSpace(settings.freeDiskSpaceRequiredBytes)) {

--- a/dtglib/src/main/java/com/kaltura/dtg/MetaDataFutureMap.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/MetaDataFutureMap.java
@@ -1,0 +1,35 @@
+package com.kaltura.dtg;
+
+import java.util.concurrent.Future;
+
+/**
+ * Class to hold future object and its state (cancelled/not cancelled)
+ * For metaDataDownloadExecutorService in DownloadService
+ */
+class MetaDataFutureMap {
+    /**
+    Future Object of the queued metadata download request
+     */
+    private Future future;
+    /**
+    Cancelled state of future object
+     */
+    private boolean isCancelled;
+
+    public MetaDataFutureMap(Future future, boolean isCancelled) {
+        this.future = future;
+        this.isCancelled = isCancelled;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        isCancelled = cancelled;
+    }
+
+    public Future getFuture() {
+        return future;
+    }
+
+    public boolean isCancelled() {
+        return isCancelled;
+    }
+}

--- a/dtglib/src/main/java/com/kaltura/dtg/Utils.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/Utils.java
@@ -141,7 +141,6 @@ public class Utils {
         InputStream inputStream = null;
         FileOutputStream fileOutputStream = null;
         HttpURLConnection conn = null;
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(10 * 1024); // 10kb: save some realloc'
 
         try {
             conn = openConnection(uri);
@@ -170,6 +169,7 @@ public class Utils {
             inputStream = conn.getInputStream();
 
             fileOutputStream = new FileOutputStream(targetFile);
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(10 * 1024); // 10kb: save some realloc'
 
             byte[] data = new byte[1024];
             int count;
@@ -183,6 +183,8 @@ public class Utils {
                     }
                 }
             }
+            
+            return byteArrayOutputStream.toByteArray();
         } finally {
             // close everything
             safeClose(fileOutputStream, inputStream);
@@ -190,7 +192,6 @@ public class Utils {
                 conn.disconnect();
             }
         }
-        return byteArrayOutputStream.toByteArray();
     }
 
     private static HttpURLConnection handleRequestRedirects(HttpURLConnection conn) throws IOException {

--- a/dtglib/src/main/java/com/kaltura/dtg/Utils.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/Utils.java
@@ -141,6 +141,7 @@ public class Utils {
         InputStream inputStream = null;
         FileOutputStream fileOutputStream = null;
         HttpURLConnection conn = null;
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(10 * 1024); // 10kb: save some realloc'
 
         try {
             conn = openConnection(uri);
@@ -169,7 +170,6 @@ public class Utils {
             inputStream = conn.getInputStream();
 
             fileOutputStream = new FileOutputStream(targetFile);
-            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(10 * 1024); // 10kb: save some realloc'
 
             byte[] data = new byte[1024];
             int count;
@@ -183,8 +183,6 @@ public class Utils {
                     }
                 }
             }
-
-            return byteArrayOutputStream.toByteArray();
         } finally {
             // close everything
             safeClose(fileOutputStream, inputStream);
@@ -192,6 +190,7 @@ public class Utils {
                 conn.disconnect();
             }
         }
+        return byteArrayOutputStream.toByteArray();
     }
 
     private static HttpURLConnection handleRequestRedirects(HttpURLConnection conn) throws IOException {


### PR DESCRIPTION
### Description of the Changes

- API to be used   `downloadItem.cancelMetadataLoading(item.getId());`

Please check our [sample](https://github.com/kaltura/playkit-dtg-android/tree/current/dtgdemo). We create [Item](https://github.com/kaltura/playkit-dtg-android/blob/87a25011898e453ed2e0d33ebf34aae8df043908/dtgdemo/src/main/java/com/kaltura/dtg/demo/MainActivity.java#L242). This holds an uniqueId for each download. 

In order to use `cancelMetadataLoading` API, please pass the same Item id.

