### PR TITLE
FEC-11534 Skip firing event only when it is load meta data is cancelled intentionally

### DIFF
--- a/dtgdemo/src/main/java/com/kaltura/dtg/demo/MainActivity.java
+++ b/dtgdemo/src/main/java/com/kaltura/dtg/demo/MainActivity.java
@@ -777,6 +777,17 @@ public class MainActivity extends ListActivity {
         try {
             downloadItem = contentManager.createItem(item.getId(), item.getUrl());
             downloadItem.loadMetadata();
+            // Uncomment it to test metadat loading cancelling
+            // You can change the sleep time to make sure that this time
+            // comes before the completion of metadata downloading
+            /*runOnUiThread(() -> {
+                try {
+                    Thread.sleep(600);
+                    downloadItem.cancelMetadataLoading(item.getId());
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            });*/
             itemStateChanged(downloadItem);
         } catch (IllegalArgumentException e) {
             toast("Failed to add item: " + e.toString());

--- a/dtgdemo/src/main/java/com/kaltura/dtg/demo/MainActivity.java
+++ b/dtgdemo/src/main/java/com/kaltura/dtg/demo/MainActivity.java
@@ -777,7 +777,7 @@ public class MainActivity extends ListActivity {
         try {
             downloadItem = contentManager.createItem(item.getId(), item.getUrl());
             downloadItem.loadMetadata();
-            // Uncomment it to test metadat loading cancelling
+            // Uncomment it to test metadata loading cancelling
             // You can change the sleep time to make sure that this time
             // comes before the completion of metadata downloading
             /*runOnUiThread(() -> {

--- a/dtglib/src/main/java/com/kaltura/dtg/DownloadService.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/DownloadService.java
@@ -404,7 +404,7 @@ public class DownloadService extends Service {
                 if (item != null) {
                     String exceptionItemId = item.getItemId();
                     MetaDataFutureMap metaDataFutureMap = metaDataDownloadMap.get(exceptionItemId);
-                    if (Thread.currentThread().isInterrupted() || exception instanceof InterruptedIOException || (metaDataFutureMap != null && !metaDataFutureMap.isCancelled())) {
+                    if (Thread.currentThread().isInterrupted() || exception instanceof InterruptedIOException || (metaDataFutureMap != null && metaDataFutureMap.isCancelled())) {
                         Log.d(TAG, "Thread interrupted for Item: " + exceptionItemId);
                     } else {
                         Log.e(TAG, "IOException Failed to download metadata for " + exceptionItemId, exception);

--- a/dtglib/src/main/java/com/kaltura/dtg/DownloadService.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/DownloadService.java
@@ -405,8 +405,12 @@ public class DownloadService extends Service {
                     String exceptionItemId = item.getItemId();
                     MetaDataFutureMap metaDataFutureMap = metaDataDownloadMap.get(exceptionItemId);
                     if (Thread.currentThread().isInterrupted() || exception instanceof InterruptedIOException || (metaDataFutureMap != null && metaDataFutureMap.isCancelled())) {
+                        // Here, we are not sending onDownloadMetaData event with exception to the app because
+                        // This came because app wanted to cancel the metadata loading {cancelMetadataLoading()}
                         Log.d(TAG, "Thread interrupted for Item: " + exceptionItemId);
                     } else {
+                        // Here, we are sending the event because there is an exception.
+                        // It could be SSL, HTTP etc exceptions.
                         Log.e(TAG, "IOException Failed to download metadata for " + exceptionItemId, exception);
                         downloadStateListener.onDownloadMetadata(item, exception);
                     }


### PR DESCRIPTION
- Cancel only if using API by App